### PR TITLE
Plan of action for Synapse state res(ets/olution)

### DIFF
--- a/drafts/fixing-synapse-state-res.org
+++ b/drafts/fixing-synapse-state-res.org
@@ -11,3 +11,7 @@
 **** TODO ~compute_event_context~ in ~synapse/state.py~
 ***** TODO Add a call to transitive reduction function before calling ~resolve_state_groups~
       Line 236
+** TODO Ensure testing covers state resolution
+*** TODO Add tests if necessary
+**** TODO Investigate whether Synapse currently has failing tests for state resolution
+*** TODO Test for backwards compatibility with previous Synapse versions

--- a/drafts/fixing-synapse-state-res.org
+++ b/drafts/fixing-synapse-state-res.org
@@ -7,6 +7,7 @@
      - =n= :: number of events
      - =m= :: "depth span" of events (max difference in depth)
 **** Maybe reduce the number of events to look at by using only previous *state* events?
+     Look in ~EventContext~ (see ~synapse/events/snapshot.py~) for potentially useful fields.
 *** Places where invariant is known to be broken
 **** TODO ~compute_event_context~ in ~synapse/state.py~
 ***** TODO Add a call to transitive reduction function before calling ~resolve_state_groups~

--- a/drafts/fixing-synapse-state-res.org
+++ b/drafts/fixing-synapse-state-res.org
@@ -1,0 +1,13 @@
+* Fixing Synapse "state resets" ([[https://github.com/matrix-org/synapse/issues/1953][Synapse issue 1953]])
+  Current as of commit [[https://github.com/matrix-org/synapse/tree/632baf799ea876d2346e934dce90d6a24cb92e37][632baf7]]
+** Root cause is lack of transitive reduction despite reliance on it as invariant
+*** TODO Implement transitive reduction of subset of DAG
+**** Can be done in =O(nm)= time
+     Where
+     - =n= :: number of events
+     - =m= :: "depth span" of events (max difference in depth)
+**** Maybe reduce the number of events to look at by using only previous *state* events?
+*** Places where invariant is known to be broken
+**** TODO ~compute_event_context~ in ~synapse/state.py~
+***** TODO Add a call to transitive reduction function before calling ~resolve_state_groups~
+      Line 236


### PR DESCRIPTION
Since I'm winding down my work on Synapse to focus on a HS of my own, here's a brain-dump of what someone (potentially my future self) would need to do to fix Synapse's "state resets" by making the state resolution code slightly saner (at somewhat of a performance cost, unfortunately).